### PR TITLE
Improve GitHub Action for linting Markdown files

### DIFF
--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -1,28 +1,15 @@
-name: markdownlint
+name: Lint Markdown files
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
-  lint_local:
+  markdownlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1.4.2
-      - name: lint markdown files local markdownlint file
-        run: |
-          npm install
-          node_modules/.bin/markdownlint content
-  lint_global:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1.4.2
-      - name: lint markdown files global markdownlint file
-        run: |
-          curl https://raw.githubusercontent.com/acend/guidelines/master/acend.json -o .markdownlint.yml
-          npm install
-          node_modules/.bin/markdownlint content
+      - uses: nosborn/github-action-markdown-cli@v1.1.1
+        with:
+          files: "content *.md"
+          config_file: ".markdownlint.json"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,25 +2,29 @@
 
 :+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
 
-## Did you find a bug?
+
+## Did you find a bug
 
 * **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/puzzle/ansible-techlabs/issues).
 
 * If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/puzzle/ansible-techlabs/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
-## Did you write a patch that fixes a bug?
+
+## Did you write a patch that fixes a bug
 
 * Open a new GitHub pull request with the patch.
 
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
-## Do you intend to add a new feature or change an existing one?
+
+## Do you intend to add a new feature or change an existing one
 
 * **Feature Request**: open an issue on GitHub and describe your feature.
 
 * **New Feature**: Implement your Feature on a fork and create a pull request. The core team will gladly check and eventually merge your pull request.
 
-## Do you have questions about the techlab?
+
+## Do you have questions about the techlab
 
 * Ask your question as an issue on GitHub
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This site is built using the static page generator [Hugo](https://gohugo.io/).
 
 The page uses the [docsy theme](https://github.com/google/docsy) which is included as a Git Submodule.
 
-After cloning the main repo, you need to initialize the submodule like this: 
+After cloning the main repo, you need to initialize the submodule like this:
 
 ```bash
 git submodule update --init --recursive


### PR DESCRIPTION
* Use an Action from Marketplace
* Only lint with local config file
* Lint top-level files as well: README.md, ...
* Fix existing linting issues